### PR TITLE
TypeHint: Fix for `List` type hint to `list`

### DIFF
--- a/monkeytypes/network_range.py
+++ b/monkeytypes/network_range.py
@@ -5,7 +5,7 @@ import re
 import socket
 import struct
 from abc import ABCMeta, abstractmethod
-from typing import Iterable, List, Tuple
+from typing import Iterable, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -64,7 +64,7 @@ class NetworkRange(object, metaclass=ABCMeta):
         return SingleIpRange(ip_address=address_str)
 
     @staticmethod
-    def filter_invalid_ranges(ranges: Iterable[str], error_msg: str) -> List[str]:
+    def filter_invalid_ranges(ranges: Iterable[str], error_msg: str) -> list[str]:
         valid_ranges = []
         for target_range in ranges:
             try:

--- a/monkeytypes/serialization.py
+++ b/monkeytypes/serialization.py
@@ -1,8 +1,8 @@
-from typing import List, Union
+from typing import Union
 
 JSONSerializable = Union[  # type: ignore[misc]
     dict[str, "JSONSerializable"],  # type: ignore[misc]
-    List["JSONSerializable"],  # type: ignore[misc]
+    list["JSONSerializable"],  # type: ignore[misc]
     int,
     str,
     float,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import Union
 
 import pytest
 
@@ -9,7 +9,7 @@ def valid_ntlm_hash() -> str:
 
 
 @pytest.fixture(scope="session")
-def invalid_ntlm_hashes() -> List[Union[str, int, float]]:
+def invalid_ntlm_hashes() -> list[Union[str, int, float]]:
     return [
         0,
         1,


### PR DESCRIPTION
Changed `List` type hint to `list` in :

- `tests/conftest.py` file.
- `monkeytypes/serialization.py` file.
- `monkeytypes/network_range` file.