### PR TITLE
TypeHint: Fix for `Tuple` type hint to `tuple`

### DIFF
--- a/monkeytypes/agent_plugin_manifest.py
+++ b/monkeytypes/agent_plugin_manifest.py
@@ -1,5 +1,5 @@
 import re
-from typing import Callable, Mapping, Optional, Self, Tuple, Type
+from typing import Callable, Mapping, Optional, Self, Type
 
 from pydantic import ConstrainedStr, HttpUrl
 from semver import VersionInfo
@@ -66,11 +66,11 @@ class AgentPluginManifest(InfectionMonkeyBaseModel):
 
     name: PluginName
     plugin_type: AgentPluginType
-    supported_operating_systems: Tuple[OperatingSystem, ...] = (
+    supported_operating_systems: tuple[OperatingSystem, ...] = (
         OperatingSystem.WINDOWS,
         OperatingSystem.LINUX,
     )
-    target_operating_systems: Tuple[OperatingSystem, ...] = (
+    target_operating_systems: tuple[OperatingSystem, ...] = (
         OperatingSystem.WINDOWS,
         OperatingSystem.LINUX,
     )

--- a/monkeytypes/network_range.py
+++ b/monkeytypes/network_range.py
@@ -5,7 +5,7 @@ import re
 import socket
 import struct
 from abc import ABCMeta, abstractmethod
-from typing import Iterable, Tuple
+from typing import Iterable
 
 logger = logging.getLogger(__name__)
 
@@ -106,7 +106,7 @@ class NetworkRange(object, metaclass=ABCMeta):
         return False
 
     @staticmethod
-    def _range_to_ips(ip_range: str) -> Tuple[str, str]:
+    def _range_to_ips(ip_range: str) -> tuple[str, str]:
         ips = ip_range.split("-")
         ips = [ip.strip() for ip in ips]
         ips = sorted(ips, key=lambda ip: socket.inet_aton(ip))


### PR DESCRIPTION
Changed `Tuple` type hint to `tuple` in :

- tests/test_agent_plugin_manifest.py file.
- monkeytypes/network_range file.

Also, All the Test Cases passed.