### PR TITLE
Typehint: Change `typing.Sequence` to `collection.abc.Sequence` type hint

### DIFF
--- a/monkeytypes/agent_plugin_manifest.py
+++ b/monkeytypes/agent_plugin_manifest.py
@@ -1,5 +1,5 @@
 import re
-from typing import Callable, Mapping, Optional, Self, Tuple, Type
+from typing import Callable, Mapping, Optional, Self, Tuple
 
 from pydantic import ConstrainedStr, HttpUrl
 from semver import VersionInfo
@@ -82,4 +82,4 @@ class AgentPluginManifest(InfectionMonkeyBaseModel):
     safe: bool = False
 
     class Config(InfectionMonkeyModelConfig):
-        json_encoders: Mapping[Type, Callable] = {PluginVersion: lambda v: str(v)}
+        json_encoders: Mapping[type, Callable] = {PluginVersion: lambda v: str(v)}

--- a/monkeytypes/base_models.py
+++ b/monkeytypes/base_models.py
@@ -1,5 +1,5 @@
 import json
-from typing import Sequence
+from collections.abc import Sequence
 
 from pydantic import BaseModel, Extra, ValidationError
 

--- a/monkeytypes/concurrency.py
+++ b/monkeytypes/concurrency.py
@@ -1,5 +1,5 @@
 from types import TracebackType
-from typing import Optional, Protocol, Type
+from typing import Optional, Protocol
 
 
 class BasicLock(Protocol):
@@ -8,7 +8,7 @@ class BasicLock(Protocol):
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
+        exc_type: Optional[type[BaseException]],
         exc_val: Optional[BaseException],
         exc_tb: Optional[TracebackType],
     ) -> Optional[bool]:


### PR DESCRIPTION
- Changed Type `typing.Sequence` hint to `collections.abc.Sequence` in `base_models.py`.
- Also, All the Test Cases `passed`.