### PR TITLE
Typehint: Change `typing.Sequence` typehint to `collection.abc.Sequence`

### DIFF
--- a/monkeytypes/base_models.py
+++ b/monkeytypes/base_models.py
@@ -1,5 +1,5 @@
 import json
-from typing import Sequence
+from collections.abc import Sequence
 
 from pydantic import BaseModel, Extra, ValidationError
 


### PR DESCRIPTION
- Changed Type `typing.Sequence` hint to `collections.abc.Sequence` in `base_models.py`.
- Also, All the Test Cases `passed`.