### PR TITLE
Typehint: Change `typing.Mapping` to `collection.abc.Mapping` type hint

### DIFF
--- a/monkeytypes/agent_plugin_manifest.py
+++ b/monkeytypes/agent_plugin_manifest.py
@@ -1,5 +1,6 @@
 import re
-from typing import Callable, Mapping, Optional, Self
+from typing import Callable, Optional, Self
+from collections.abc import Mapping
 
 from pydantic import ConstrainedStr, HttpUrl
 from semver import VersionInfo


### PR DESCRIPTION
- Changed Type `typing.Mapping` hint to `collections.abc.Mapping` in `agent_plugin_manifest.py`.
- Also, All the Test Cases `passed`.