### PR TITLE
Typehint: Fix `typing.Callable` to `collection.abc.Callable` type hint

### DIFF
--- a/monkeytypes/agent_plugin_manifest.py
+++ b/monkeytypes/agent_plugin_manifest.py
@@ -1,6 +1,6 @@
 import re
-from typing import Callable, Optional, Self
-from collections.abc import Mapping
+from typing import Optional, Self
+from collections.abc import Callable, Mapping
 
 from pydantic import ConstrainedStr, HttpUrl
 from semver import VersionInfo

--- a/monkeytypes/b64_bytes.py
+++ b/monkeytypes/b64_bytes.py
@@ -1,5 +1,6 @@
 from base64 import b64decode
-from typing import Any, Callable, Generator
+from typing import Any, Generator
+from collections.abc import Callable
 
 from pydantic import errors
 


### PR DESCRIPTION
Changed Type `typing.Iterable` hint to `collections.abc.Iterable`:

- `monkeytypes/agent_plugin_manifest.py` file.
- `monkeytypes/b64_bytes.py` file.

- Also, All the Test Cases `passed`.