### PR TITLE
Typehint: fix `type.Generator` to `Collection.abc.Generator` typehint

### DIFF
--- a/monkeytypes/b64_bytes.py
+++ b/monkeytypes/b64_bytes.py
@@ -1,6 +1,6 @@
 from base64 import b64decode
-from typing import Any, Generator
-from collections.abc import Callable
+from typing import Any
+from collections.abc import Callable, Generator
 
 from pydantic import errors
 


### PR DESCRIPTION
- Changed Type `typing.Generator` hint to `collections.abc.Generator` in `monkeytypes/b64_bytes.py` file.
- Also, All the Test Cases `passed`.