### PR TITLE
Add facade for certain pydantic BaseModel methods

### DIFF
--- a/monkeytypes/base_models.py
+++ b/monkeytypes/base_models.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any
+from typing import Any, Union
 
 from pydantic import BaseModel, ConfigDict, ValidationError
 
@@ -71,6 +71,21 @@ class InfectionMonkeyBaseModel(BaseModel):
 
     def to_json_dict(self):
         return self.model_dump(mode="json")
+
+    def to_dict(self):
+        return self.model_dump()
+
+    def to_json(self):
+        return self.model_dump_json()
+
+    def from_json(self, json_data: Union[str, bytes, bytearray]):
+        return self.model_validate_json(json_data)
+
+    def copy(self):
+        return self.model_copy()
+
+    def deep_copy(self):
+        return self.model_copy(deep=True)
 
 
 class MutableInfectionMonkeyBaseModel(InfectionMonkeyBaseModel):

--- a/tests/test_base_models.py
+++ b/tests/test_base_models.py
@@ -18,18 +18,19 @@ class MutableModel(MutableInfectionMonkeyBaseModel):
     float_model: Optional[FloatModel]
 
 
-METHODS_DICT = {"example_field": 42.0}
-METHODS_JSON = '{"example_field":42.0}'
+METHODS_DICT = {"example_field": 42.0, "example_list": [1, 2, 3]}
+METHODS_JSON = '{"example_field":42.0,"example_list":[1,2,3]}'
 METHODS_NOT_VALID_JSON = '{"example_field": "not_an_int"}'
 
 
-class MethodsModel(InfectionMonkeyBaseModel):
+class MethodsModel(MutableInfectionMonkeyBaseModel):
     example_field: float
+    example_list: list
 
 
 @pytest.fixture
 def methods_model():
-    return MethodsModel(example_field=42.0)
+    return MethodsModel(example_field=42.0, example_list=[1, 2, 3])
 
 
 def test_set_value_error():
@@ -86,8 +87,24 @@ def test_base_model_from_json_invalid(methods_model):
 
 
 def test_base_model_copy(methods_model):
-    assert methods_model == methods_model.copy()
+    model_copy = methods_model.copy()
+
+    assert methods_model == model_copy
+
+    model_copy.example_field = methods_model.example_field - 10
+    model_copy.example_list.append(4)
+
+    assert methods_model.example_field != model_copy.example_field
+    assert len(model_copy.example_list) == len(methods_model.example_list)
 
 
 def test_base_model_deep_copy(methods_model):
-    assert methods_model == methods_model.deep_copy()
+    model_copy = methods_model.deep_copy()
+
+    assert methods_model == model_copy
+
+    model_copy.example_field = methods_model.example_field + 9
+    model_copy.example_list.append(4)
+
+    assert methods_model.example_field != model_copy.example_field
+    assert len(model_copy.example_list) != len(methods_model.example_list)

--- a/tests/test_base_models.py
+++ b/tests/test_base_models.py
@@ -18,6 +18,20 @@ class MutableModel(MutableInfectionMonkeyBaseModel):
     float_model: Optional[FloatModel]
 
 
+METHODS_DICT = {"example_field": 42.0}
+METHODS_JSON = '{"example_field":42.0}'
+METHODS_NOT_VALID_JSON = '{"example_field": "not_an_int"}'
+
+
+class MethodsModel(InfectionMonkeyBaseModel):
+    example_field: float
+
+
+@pytest.fixture
+def methods_model():
+    return MethodsModel(example_field=42.0)
+
+
 def test_set_value_error():
     ValueFloatModel = FloatModel(number=4.1)
     with pytest.raises(ValueError):
@@ -48,3 +62,32 @@ def test_mutable_base_model_config_update():
         ImmutableMutableConfigModel.model_config.get(key) == value
         for key, value in InfectionMonkeyModelConfig.items()
     )
+
+
+def test_base_model_to_json_dict(methods_model):
+    assert methods_model.to_json_dict() == METHODS_DICT
+
+
+def test_base_model_to_dict(methods_model):
+    assert methods_model.to_dict() == METHODS_DICT
+
+
+def test_base_model_to_json(methods_model):
+    assert methods_model.to_json() == METHODS_JSON
+
+
+def test_base_model_from_json(methods_model):
+    assert methods_model == methods_model.from_json(METHODS_JSON)
+
+
+def test_base_model_from_json_invalid(methods_model):
+    with pytest.raises(ValueError):
+        methods_model.from_json(METHODS_NOT_VALID_JSON)
+
+
+def test_base_model_copy(methods_model):
+    assert methods_model == methods_model.copy()
+
+
+def test_base_model_deep_copy(methods_model):
+    assert methods_model == methods_model.deep_copy()

--- a/vulture_allowlist.py
+++ b/vulture_allowlist.py
@@ -59,6 +59,11 @@ b64_bytes_validator.msg_template
 
 InfectionMonkeyBaseModel.model_config
 InfectionMonkeyBaseModel.to_json_dict
+InfectionMonkeyBaseModel.to_dict
+InfectionMonkeyBaseModel.to_json
+InfectionMonkeyBaseModel.from_json
+InfectionMonkeyBaseModel.copy
+InfectionMonkeyBaseModel.deep_copy
 MutableInfectionMonkeyBaseModel.model_config
 
 BasicLock.exc_type


### PR DESCRIPTION
This allows us in future if the names change of these methods to change it only in one place