### PR TITLE
Add LocalMachineInfo model

### DIFF
--- a/monkeytypes/__init__.py
+++ b/monkeytypes/__init__.py
@@ -29,6 +29,7 @@ from .file_extension import FileExtension
 from .percent import Percent, PercentLimited, NonNegativeFloat
 from .b64_bytes import B64Bytes
 from .network_range import InvalidNetworkRangeError, NetworkRange, CidrRange, IpRange, SingleIpRange
+from .local_machine_info import LocalMachineInfo
 
 from .credentials.email_address import EmailAddress
 from .credentials.username import Username

--- a/monkeytypes/local_machine_info.py
+++ b/monkeytypes/local_machine_info.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+from typing import Optional
+
+from monkeytypes import MutableInfectionMonkeyBaseModel, OperatingSystem
+
+
+class LocalMachineInfo(MutableInfectionMonkeyBaseModel):
+    """
+    Contains information about the local machine
+
+    :param operating_system: Operating system of the local machine
+    :param temporary_directory: Path to a temporary directory on the local machine
+                                to store artifacts
+    :param interface_to_target: Interface on the local machine that can be reached
+                                by the target machine
+    """
+
+    operating_system: OperatingSystem
+    temporary_directory: Path
+    interface_to_target: Optional[str] = None
+
+    def set_interface_to_target(self, interface_to_target: str):
+        self.interface_to_target = interface_to_target
+
+    def reset_interface_to_target(self):
+        self.interface_to_target = None

--- a/tests/test_local_machine_info.py
+++ b/tests/test_local_machine_info.py
@@ -1,0 +1,23 @@
+from monkeytypes import OperatingSystem
+
+from monkeytypes import LocalMachineInfo
+
+LOCAL_MACHINE_INFO_OBJECT = LocalMachineInfo(
+    operating_system=OperatingSystem.WINDOWS,
+    interface_to_target=None,
+    temporary_directory="temp/o/rary",
+)
+
+LOCAL_MACHINE_INFO_DICT = {
+    "operating_system": "windows",
+    "interface_to_target": None,
+    "temporary_directory": "temp\\o\\rary",
+}
+
+
+def test_local_machine_info__serialization():
+    assert LOCAL_MACHINE_INFO_OBJECT.to_json_dict() == LOCAL_MACHINE_INFO_DICT
+
+
+def test_local_machine_info__deserialization():
+    assert LocalMachineInfo(**LOCAL_MACHINE_INFO_DICT) == LOCAL_MACHINE_INFO_OBJECT


### PR DESCRIPTION
Adds a new model, `LocalMachineInfo`, in support of https://github.com/guardicore/monkey/issues/3751