### PR TITLE
Fix incomplete PercentLimited JSON schema generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 the [PEP 440 version scheme](https://peps.python.org/pep-0440/#version-scheme).
 
 
+## [Unreleased]
+## Fixed
+- Incomplete Percent/PercentLimited JSON schema generation.
+
 ## [0.6.0] - 2024-02-26
 ### Changed
 - Allow error handling to be overridden in InfectionMonkeyBaseModel.

--- a/tests/test_percent.py
+++ b/tests/test_percent.py
@@ -1,5 +1,5 @@
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, TypeAdapter
 
 from monkeytypes import Percent, PercentLimited
 
@@ -31,6 +31,16 @@ def test_as_decimal_fraction(input_value: float, expected_decimal_fraction: floa
     assert Model(p=input_value).p.as_decimal_fraction() == expected_decimal_fraction  # type: ignore [arg-type]  # noqa: E501
 
 
+def test_percent_schema():
+    adapter = TypeAdapter(Percent)
+
+    schema = adapter.json_schema()
+
+    assert "description" in schema
+    assert "maximum" not in schema
+    assert schema["minimum"] == 0.0
+
+
 class ModelLimited(BaseModel):
     p: PercentLimited
 
@@ -51,3 +61,13 @@ def test_valid_percent_limited(input_value: float):
 )
 def test_as_decimal_fraction_limited(input_value: float, expected_decimal_fraction: float):
     assert ModelLimited(p=input_value).p.as_decimal_fraction() == expected_decimal_fraction  # type: ignore [arg-type]  # noqa: E501
+
+
+def test_percent_limited_schema():
+    adapter = TypeAdapter(PercentLimited)
+
+    schema = adapter.json_schema()
+
+    assert "description" in schema
+    assert schema["maximum"] == 100.0
+    assert schema["minimum"] == 0.0


### PR DESCRIPTION
When migrating from Pydantic 1 to Pydantic 2, this detail was missed. The schema generated for PercentLimited did not include the maximum. The type's schema needed to be redefined using Annotated in order to add the maximum to the JSON schema.